### PR TITLE
Improve usage example code in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,25 +18,25 @@ yarn add xbr-js
 
 ```js
 import {xbr2x, xbr3x, xbr4x} from 'xbr-js';
+```
 
-...
+```js
+// if you have an <img>, draw it on a canvas first
+const canvas = document.createElement('canvas');
+const sourceWidth = canvas.width = img.width;
+const sourceHeight = canvas.height = img.height;
+const context = canvas.getContext('2d');
+context.drawImage(img, 0, 0);
 
-const
-  scaledWidth = sourceWidth * 2,
-  scaledHeight = sourceHeight * 2,
-  originalImageData = context.getImageData(
-    0,
-    0,
-    sourceWidth,
-    sourceHeight);
+// the following code will apply xbr2x to an existing canvas
+canvas.width = sourceWidth * 2;
+canvas.height = sourceHeight * 2;
 
+const originalImageData = context.getImageData(0, 0, sourceWidth, sourceHeight);
 const originalPixelView = new Uint32Array(originalImageData.data.buffer);
-
 const scaledPixelView = xbr2x(originalPixelView, sourceWidth, sourceHeight);
-
-const scaledImageData = new ImageData(new Uint8ClampedArray(scaledPixelView.buffer), scaledWidth, scaledHeight);
-canvas.width = scaledWidth;
-canvas.height = scaledHeight;
+const scaledImageData = context.createImageData(canvas.width, canvas.height);
+scaledImageData.data.set(new Uint8ClampedArray(scaledPixelView.buffer));
 
 context.putImageData(scaledImageData, 0, 0);
 ```


### PR DESCRIPTION
The latest version of xBRjs expects a canvas with an image already drawn on it, which is much better compared to previous versions that expected an `<img>`. However, the current usage example code in the readme can be confusing, as it assumes you have `canvas` (with an image drawn on it), `context`, `sourceWidth` and `sourceHeight` variables.

I split the example code up in two sections, the first section is optional and explains how to turn an `<img>` into a canvas, and the second section shows how to apply xbr2x to an existing canvas. By doing so, this example code should help both those who have an `<img>`, and those who have an existing canvas.

Furthermore, I eliminated `scaledWidth` and `scaledHeight` and managed to keep the example code concise like it was before.

Lastly, I replaced `new ImageData` with `context.createImageData`, because the former is not available in all environments. See the browser compatibility table for the ImageData constructor for more information: https://developer.mozilla.org/en-US/docs/Web/API/ImageData